### PR TITLE
Skip all ports in DHCP agents on different hosts

### DIFF
--- a/networking_calico/agent/linux/dhcp.py
+++ b/networking_calico/agent/linux/dhcp.py
@@ -38,3 +38,10 @@ class DnsmasqRouted(dhcp.Dnsmasq):
         cmd.append('--enable-ra')
 
         return cmd
+
+    def _iter_hosts(self):
+        # we only care about ports on the same node as the dhcp agent
+        # so remove the rest
+        self.network.ports = [p for p in self.network.ports
+                              if p['binding:host_id'] == self.conf.host]
+        return super(DnsmasqRouted, self)._iter_hosts()


### PR DESCRIPTION
In the Calico DHCP agent deployments, the agent is only
responsible for serving DHCP to the instances on the same
node it resides on.

This patch leverages that restriction to skip generating
entries for any ports that are bound to hosts other than
the one it serves.

Change-Id: I8eb73e6b53cd6091292f74b6a370ed860cfdf705