### PR TITLE
Make "ipv6-icmp" a valid protocol name

### DIFF
--- a/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -139,6 +139,8 @@ def _neutron_rule_to_etcd_rule(rule):
     # Map the protocol field from Neutron to etcd format.
     if rule['protocol'] is None or rule['protocol'] == -1:
         pass
+    elif rule['protocol'] == 'ipv6-icmp':
+        etcd_rule['protocol'] = 'ICMPv6'
     elif rule['protocol'] == 'icmp':
         etcd_rule['protocol'] = {'IPv4': 'ICMP',
                                  'IPv6': 'ICMPv6'}[ethertype]


### PR DESCRIPTION
Recent versions of Neutron use "ipv6-icmp" instead of "icmp" or
"icmpv6", now designated as legacy names for ICMP on IPv6. This
patch adds "ipv6-icmp" as a valid protocol name.
Fixes https://github.com/projectcalico/networking-calico/issues/4