### PR TITLE
patch for ipv6-icmp code and type rules

### DIFF
--- a/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -142,7 +142,8 @@ def _neutron_rule_to_etcd_rule(rule):
     elif rule['protocol'] == 'ipv6-icmp':
         etcd_rule['protocol'] = {'IPv6': 'ICMPv6'}[ethertype]
     elif rule['protocol'] == 'icmp':
-        etcd_rule['protocol'] = {'IPv4': 'ICMP'}[ethertype]
+        etcd_rule['protocol'] = {'IPv4': 'ICMP',
+                                 'IPv6': 'ICMPv6'}[ethertype]
     elif isinstance(rule['protocol'], int):
         etcd_rule['protocol'] = rule['protocol']
     else:

--- a/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -140,17 +140,16 @@ def _neutron_rule_to_etcd_rule(rule):
     if rule['protocol'] is None or rule['protocol'] == -1:
         pass
     elif rule['protocol'] == 'ipv6-icmp':
-        etcd_rule['protocol'] = 'ICMPv6'
+        etcd_rule['protocol'] = {'IPv6': 'ICMPv6'}[ethertype]
     elif rule['protocol'] == 'icmp':
-        etcd_rule['protocol'] = {'IPv4': 'ICMP',
-                                 'IPv6': 'ICMPv6'}[ethertype]
+        etcd_rule['protocol'] = {'IPv4': 'ICMP'}[ethertype]
     elif isinstance(rule['protocol'], int):
         etcd_rule['protocol'] = rule['protocol']
     else:
         etcd_rule['protocol'] = rule['protocol'].upper()
 
     port_spec = None
-    if rule['protocol'] == 'icmp':
+    if rule['protocol'] == 'icmp' or rule['protocol'] == 'ipv6-icmp':
         # OpenStack stashes the ICMP match criteria in
         # port_range_min/max.
         icmp_fields = {}

--- a/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -140,7 +140,7 @@ def _neutron_rule_to_etcd_rule(rule):
     if rule['protocol'] is None or rule['protocol'] == -1:
         pass
     elif rule['protocol'] == 'ipv6-icmp':
-        etcd_rule['protocol'] = {'IPv6': 'ICMPv6'}[ethertype]
+        etcd_rule['protocol'] = 'ICMPv6'
     elif rule['protocol'] == 'icmp':
         etcd_rule['protocol'] = {'IPv4': 'ICMP',
                                  'IPv6': 'ICMPv6'}[ethertype]


### PR DESCRIPTION
The patch to make ipv6-icmp a valid protocol worked to some extent but failed to allow specific icmp6 type and code rules. This patch has been tested successfully on calico 3.12 and Openstack Train.

[root@sto3-openstack-cl-3 ~]# ip6tables -S |grep icmp
-A cali-pi-_ImXU7x--6s-BGPNGiGg -p ipv6-icmp -m comment --comment "cali:BAyIFGZ3jbBpEC3N" -j MARK --set-xmark 0x10000/0x10000
...
[root@sto3-openstack-cl-3 ~]# ip6tables -S |grep icmp
-A cali-pi-_ImXU7x--6s-BGPNGiGg -p ipv6-icmp -m comment --comment "cali:Se5-UR_PpfZfjst0" -m icmp6 --icmpv6-type 128/0 -j MARK --set-xmark 0x10000/0x10000
...