### PR TITLE
Support IP protocol names in SG rules

### DIFF
--- a/networking_calico/compat.py
+++ b/networking_calico/compat.py
@@ -59,3 +59,13 @@ try:
 except ImportError:
     # Pre-Ocata.
     from neutron.manager import NeutronManager as plugin_dir
+
+try:
+    # Present here since January 2016 (commit c8be1a1be91).
+    from neutron_lib.constants import IP_PROTOCOL_MAP
+except ImportError:
+    # We probably don't need to support IP protocol names for older
+    # OpenStack versions.  But if such a need arises, we can add code
+    # here to get IP_PROTOCOL_MAP in the appropriate way from those
+    # old versions.
+    IP_PROTOCOL_MAP = {}

--- a/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -53,6 +53,15 @@ sys.modules['sqlalchemy.orm'] = m_sqlalchemy.orm
 sys.modules['sqlalchemy.orm.exc'] = m_sqlalchemy.orm.exc
 sys.modules['networking_calico.compat'] = m_compat = mock.MagicMock()
 
+# Set up some IP protocol mappings to test.  (Unfortunately, importing
+# the real IP_PROTOCOL_MAP from neutron_lib.constants tries to pull in
+# too much other stuff.)
+m_compat.IP_PROTOCOL_MAP = {
+    'esp': 50,
+    'ah': 51,
+    'rsvp': 46,
+}
+
 port1 = {'binding:vif_type': 'tap',
          'binding:host_id': 'felix-host-1',
          'id': 'DEADBEEF-1234-5678',

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1161,6 +1161,26 @@ class TestPluginEtcd(TestPluginEtcdBase):
             'action': 'Allow',
         })
 
+    def test_neutron_rule_to_etcd_rule_protocol_name(self):
+        for neutron_protocol_spec, calico_protocol_spec in \
+                lib.m_compat.IP_PROTOCOL_MAP.items():
+            self.assertNeutronToEtcd(_neutron_rule_from_dict({
+                "protocol": neutron_protocol_spec,
+            }), {
+                'action': 'Allow',
+                'ipVersion': 4,
+                'protocol': calico_protocol_spec,
+            })
+
+    def test_neutron_rule_to_etcd_rule_protocol_any(self):
+        for protocol_spec in ['any', 0]:
+            self.assertNeutronToEtcd(_neutron_rule_from_dict({
+                "protocol": protocol_spec,
+            }), {
+                'action': 'Allow',
+                'ipVersion': 4,
+            })
+
     def test_not_master_does_not_resync(self):
         """Test that a driver that is not master does not resync."""
         # Initialize the state early to put the elector in place, then override


### PR DESCRIPTION
Per
https://docs.openstack.org/api-ref/network/v2/?expanded=create-security-group-rule-detail#security-group-rules-security-group-rules:

> The IP protocol can be represented by a string, an integer, or
> null. Valid string or integer values are any or 0, ah or 51, dccp or
> 33, egp or 8, esp or 50, gre or 47, icmp or 1, icmpv6 or 58, igmp or
> 2, ipip or 4, ipv6-encap or 41, ipv6-frag or 44, ipv6-icmp or 58,
> ipv6-nonxt or 59, ipv6-opts or 60, ipv6-route or 43, ospf or 89, pgm
> or 113, rsvp or 46, sctp or 132, tcp or 6, udp or 17, udplite or
> 136, vrrp or 112. Additionally, any integer value between [0-255] is
> also valid. The string any (or integer 0) means all IP
> protocols. See the constants in neutron_lib.constants for the most
> up-to-date list of supported strings.

Fixes https://github.com/projectcalico/calico/issues/2111
