### PR TITLE
Test and fix EtcdWatcher's resilience to etcd server restart

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -6,3 +6,4 @@ test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/plugins/ml2/drivers/calico/test $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list
+test_run_concurrency=echo 1

--- a/networking_calico/etcdutils.py
+++ b/networking_calico/etcdutils.py
@@ -299,9 +299,14 @@ class EtcdWatcher(object):
                         # Write to a key in the tree that we are watching.  If
                         # the watch is working normally, it will report this
                         # event.
-                        self.debug_reporter("Write round-trip key")
-                        etcdv3.put(self.prefix + self.round_trip_suffix,
-                                   str(time_now))
+                        try:
+                            etcdv3.put(self.prefix + self.round_trip_suffix,
+                                       str(time_now))
+                            self.debug_reporter("Wrote round-trip key")
+                        except ConnectionFailedError:
+                            LOG.exception(
+                                "etcd not available for watch round trip check"
+                            )
 
                     # Sleep until time for next write.
                     eventlet.sleep(WATCH_TIMEOUT_SECS / 3)

--- a/networking_calico/etcdutils.py
+++ b/networking_calico/etcdutils.py
@@ -277,7 +277,7 @@ class EtcdWatcher(object):
                 # Loop until we should cancel the watch, either because of
                 # inactivity or because of stop() having been called.
                 while not self._stopped:
-                    self.debug_reporter("Start of loop (not stopped)")
+                    self.debug_reporter("Start of loop")
                     # If WATCH_TIMEOUT_SECS has now passed since the last watch
                     # event, break out of this loop.  If we are also writing a
                     # key within the tree every WATCH_TIMEOUT_SECS / 3 seconds,

--- a/networking_calico/etcdutils.py
+++ b/networking_calico/etcdutils.py
@@ -124,6 +124,7 @@ class EtcdWatcher(object):
         self.round_trip_suffix = round_trip_suffix
         self.dispatcher = PathDispatcher()
         self._stopped = False
+        self.debug_reporter = lambda msg: msg
 
     def register_path(self, *args, **kwargs):
         self.dispatcher.register(*args, **kwargs)
@@ -276,6 +277,7 @@ class EtcdWatcher(object):
                 # Loop until we should cancel the watch, either because of
                 # inactivity or because of stop() having been called.
                 while not self._stopped:
+                    self.debug_reporter("Start of loop (not stopped)")
                     # If WATCH_TIMEOUT_SECS has now passed since the last watch
                     # event, break out of this loop.  If we are also writing a
                     # key within the tree every WATCH_TIMEOUT_SECS / 3 seconds,
@@ -288,6 +290,7 @@ class EtcdWatcher(object):
                     if time_now > last_event_time + WATCH_TIMEOUT_SECS:
                         if self.round_trip_suffix is not None:
                             LOG.warning("Watch is not working")
+                            self.debug_reporter("Watch is not working")
                         else:
                             LOG.debug("Watch timed out")
                         break
@@ -296,6 +299,7 @@ class EtcdWatcher(object):
                         # Write to a key in the tree that we are watching.  If
                         # the watch is working normally, it will report this
                         # event.
+                        self.debug_reporter("Write round-trip key")
                         etcdv3.put(self.prefix + self.round_trip_suffix,
                                    str(time_now))
 
@@ -310,6 +314,7 @@ class EtcdWatcher(object):
             # Spawn a greenlet to cancel the watch if it stops working, or if
             # stop() is called.  Cancelling the watch adds None to the event
             # stream, so the following for loop will see that.
+            self.debug_reporter("Start _cancel_watch_if_broken")
             eventlet.spawn(_cancel_watch_if_broken)
 
             for event in event_stream:

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
@@ -59,6 +59,7 @@ class TestElection(unittest.TestCase):
         self.sys_exit_p.stop()
         self.print_exc_patch.stop()
         eventlet.sleep = self._real_sleep
+        etcdv3._client = None
         super(TestElection, self).tearDown()
 
     def test_invalid(self):

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -79,6 +79,10 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
         self.reset_etcd_after = None
         self.assert_etcd_writes_deletes = True
 
+    def tearDown(self):
+        etcdv3._client = None
+        super(_TestEtcdBase, self).tearDown()
+
     def maybe_reset_etcd(self):
         if self.reset_etcd_after is not None:
             self.reset_etcd_after -= 1

--- a/networking_calico/tests/test_etcdutils.py
+++ b/networking_calico/tests/test_etcdutils.py
@@ -194,6 +194,10 @@ class TestEtcdWatcher(unittest.TestCase):
         self.m_dispatcher = Mock(spec=PathDispatcher)
         self.watcher.dispatcher = self.m_dispatcher
 
+    def tearDown(self):
+        etcdv3._client = None
+        super(TestEtcdWatcher, self).tearDown()
+
     def test_mainline(self):
         # Set up 3 iterations through the watcher's main loop.
         #

--- a/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking_calico/tests/test_fv_etcdutils.py
@@ -35,11 +35,14 @@ from networking_calico import etcdv3
 
 _log = logging.getLogger(__name__)
 
+ETCD_IMAGE = "quay.io/coreos/etcd:v3.3.11"
+
 
 class TestFVEtcdutils(unittest.TestCase):
     def setUp(self):
         super(TestFVEtcdutils, self).setUp()
         self.etcd_server_running = False
+        os.system("docker pull " + ETCD_IMAGE)
 
     def tearDown(self):
         self.stop_etcd_server()
@@ -47,7 +50,7 @@ class TestFVEtcdutils(unittest.TestCase):
 
     def start_etcd_server(self):
         os.system("docker run -d --rm --net=host --name etcd" +
-                  " quay.io/coreos/etcd:v3.3.11 etcd" +
+                  " " + ETCD_IMAGE + " etcd" +
                   " --advertise-client-urls http://127.0.0.1:2379" +
                   " --listen-client-urls http://0.0.0.0:2379")
         self.etcd_server_running = True
@@ -55,13 +58,13 @@ class TestFVEtcdutils(unittest.TestCase):
     def wait_etcd_ready(self):
         self.assertTrue(self.etcd_server_running)
         ready = False
-        for ii in range(5):
+        for ii in range(10):
             try:
                 etcdv3.get_status()
                 ready = True
                 break
             except Exception:
-                eventlet.sleep(1)
+                eventlet.sleep(2)
         self.assertTrue(ready)
 
     def stop_etcd_server(self):

--- a/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking_calico/tests/test_fv_etcdutils.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+test_fv_etcdutils
+~~~~~~~~~~~~~~
+
+Tests for etcdutils with a real etcd server.
+"""
+
+from __future__ import print_function
+
+import logging
+import os
+import unittest
+
+import eventlet
+eventlet.monkey_patch()
+
+from networking_calico.common import config as calico_config
+from networking_calico.compat import cfg
+from networking_calico import etcdutils
+
+_log = logging.getLogger(__name__)
+
+
+class TestFVEtcdutils(unittest.TestCase):
+    def setUp(self):
+        super(TestFVEtcdutils, self).setUp()
+
+    def tearDown(self):
+        self.stop_etcd_server()
+        super(TestFVEtcdutils, self).tearDown()
+
+    def start_etcd_server(self):
+        os.system("docker run -d --rm --net=host --name etcd" +
+                  " quay.io/coreos/etcd:v3.3.11 etcd" +
+                  " --advertise-client-urls http://127.0.0.1:2379" +
+                  " --listen-client-urls http://0.0.0.0:2379")
+
+    def stop_etcd_server(self):
+        os.system("docker kill etcd")
+
+    def test_restart_resilience(self):
+        # Start a real local etcd server.
+        self.start_etcd_server()
+
+        # Set up minimal config, so EtcdWatcher will use that etcd.
+        calico_config.register_options(cfg.CONF)
+
+        # Create and start an EtcdWatcher.
+        ew = etcdutils.EtcdWatcher('/calico/felix/v2/abc/host',
+                                   '/round-trip-check')
+        debug_msgs = []
+        ew.debug_reporter = lambda msg: debug_msgs.append(msg)
+        eventlet.spawn(ew.start)
+
+        # Let it run for 10 seconds normally.
+        eventlet.sleep(10)
+
+        # Stop the etcd server.
+        debug_msgs.append("Stopping etcd server")
+        self.stop_etcd_server()
+
+        # Let it run for 10 seconds more.
+        eventlet.sleep(10)
+
+        # Restart the etcd server.
+        debug_msgs.append("Restarting etcd server")
+        self.start_etcd_server()
+
+        # Let it run for 10 seconds more.
+        eventlet.sleep(10)
+
+        # Stop the EtcdWatcher.
+        debug_msgs.append("Stopping EtcdWatcher")
+        ew.stop()
+
+        # Find the message for "Restarting etcd server" and count
+        # "Write round-trip key" messages before and after that.  Both
+        # counts should be non-zero if the EtcdWatcher is working
+        # correctly before and after the etcd server restart.
+        num_key_writes_before_restart = 0
+        num_key_writes_after_restart = 0
+        seen_restart_msg = False
+        for msg in debug_msgs:
+            if msg == "Restarting etcd server":
+                seen_restart_msg = True
+            if msg == "Write round-trip key":
+                if seen_restart_msg:
+                    num_key_writes_after_restart += 1
+                else:
+                    num_key_writes_before_restart += 1
+        self.assertGreater(
+            num_key_writes_before_restart,
+            0,
+            msg="No round-trip key writes before restart: %r" % debug_msgs,
+        )
+        self.assertGreater(
+            num_key_writes_after_restart,
+            0,
+            msg="No round-trip key writes after restart: %r" % debug_msgs,
+        )
+
+        # Kill the etcd server.
+        self.stop_etcd_server()

--- a/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking_calico/tests/test_fv_etcdutils.py
@@ -64,6 +64,7 @@ class TestFVEtcdutils(unittest.TestCase):
                 ready = True
                 break
             except Exception:
+                _log.exception("etcd server not ready yet")
                 eventlet.sleep(2)
         self.assertTrue(ready)
 


### PR DESCRIPTION
This test reproduces a customer-reported problem where our Neutron
driver's Felix status watching was not resilient to the etcd server
being restarted.  The impact of that was that the Neutron driver
thought (after a following timeout period) that all the Felixes were
dead, and so refused to schedule any new VM instances.