### PR TITLE
Pin TEMPEST_BRANCH=23.0.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,7 +19,7 @@ blocks:
             - ln -s . networking-calico
             - sudo apt-get install -y tox python-all-dev python3-all-dev
             - export LIBVIRT_TYPE=qemu
-            - TEMPEST=true DEVSTACK_BRANCH=stable/rocky DEVSTACK_REPO=https://github.com/neiljerram/devstack.git ./devstack/bootstrap.sh
+            - TEMPEST=true TEMPEST_BRANCH=23.0.0 DEVSTACK_BRANCH=stable/rocky DEVSTACK_REPO=https://github.com/neiljerram/devstack.git ./devstack/bootstrap.sh
             - source ./devstack/devstackgaterc
             - cd /opt/stack/tempest
             - tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,7 +16,9 @@ blocks:
         - name: 'FV (DevStack + Tempest)'
           commands:
             - checkout
-            - ln -s . networking-calico
+            - git checkout -b devstack-test
+            - mkdir -p ~/calico
+            - ln -s `pwd` ~/calico/networking-calico
             - sudo apt-get install -y tox python-all-dev python3-all-dev
             - export LIBVIRT_TYPE=qemu
             - TEMPEST=true TEMPEST_BRANCH=23.0.0 DEVSTACK_BRANCH=stable/rocky DEVSTACK_REPO=https://github.com/neiljerram/devstack.git ./devstack/bootstrap.sh

--- a/networking_calico/agent/linux/interface.py
+++ b/networking_calico/agent/linux/interface.py
@@ -43,7 +43,8 @@ class RoutedInterfaceDriver(interface.LinuxInterfaceDriver):
         return True
 
     def plug_new(self, network_id, port_id, device_name, mac_address,
-                 bridge=None, namespace=None, prefix=None, mtu=None):
+                 bridge=None, namespace=None, prefix=None, mtu=None,
+                 link_up=True):
         """Plugin the interface."""
         ip = ip_lib.IPWrapper()
 


### PR DESCRIPTION
Surprisingly this isn't implied by DEVSTACK_BRANCH=stable/rocky, and
needs an independent setting.

Apparently Tempest releases are different from other OpenStack
components.  We have been using master, but we need 23.0.0 as this is
the latest release that supports (a) Rocky and (b) Python 2.  See
https://docs.openstack.org/releasenotes/tempest/v23.0.0.html for more
on this.

Without this pinning, we now (I guess since the release of Ussuri
yesterday) get this error in CI:

    Obtaining file:///opt/stack/tempest
    tempest requires Python '>=3.6' but the running Python is 2.7.17
