### PR TITLE
Stop using my DevStack fork, which is unnecessary and now outdated

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
             - ln -s `pwd` ~/calico/networking-calico
             - sudo apt-get install -y tox python-all-dev python3-all-dev
             - export LIBVIRT_TYPE=qemu
-            - TEMPEST=true TEMPEST_BRANCH=23.0.0 DEVSTACK_BRANCH=stable/rocky DEVSTACK_REPO=https://github.com/neiljerram/devstack.git ./devstack/bootstrap.sh
+            - TEMPEST=true TEMPEST_BRANCH=23.0.0 DEVSTACK_BRANCH=stable/rocky ./devstack/bootstrap.sh
             - source ./devstack/devstackgaterc
             - cd /opt/stack/tempest
             - tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,6 +24,7 @@ blocks:
             - TEMPEST=true TEMPEST_BRANCH=23.0.0 DEVSTACK_BRANCH=stable/rocky ./devstack/bootstrap.sh
             - source ./devstack/devstackgaterc
             - cd /opt/stack/tempest
+            - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/rocky
             - tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY
       epilogue:
         on_fail:


### PR DESCRIPTION
Specifically it was missing
https://opendev.org/openstack/devstack/commit/85dcb9ef830d79438422e9a2b3a2048747a9c0b0,
which is needed to allow stable/rocky DevStack + Tempest to continue
to work.

Also my DevStack fork was only needed temporarily back in January, for
debugging an etcd startup issue, and I should have reverted using it
immediately after getting past that issue.

With my outdated fork, UPPER_CONSTRAINTS_FILE was defaulting to
https://releases.openstack.org/constraints/upper/master, which has
just stopped working for a Rocky + Python 2 environment, giving this
error:

```
++ lib/tempest:install_tempest:692          :   tox -r --notest -efull
full create: /opt/stack/tempest/.tox/tempest
full installdeps: -chttps://releases.openstack.org/constraints/upper/master, -r/opt/stack/tempest/requirements.txt
ERROR: invocation failed (exit code 1), logfile: /opt/stack/tempest/.tox/tempest/log/full-1.log
================================== log start ===================================
Ignoring pycrypto: markers 'python_version == "3.6"' don't match your environment
Ignoring salt: markers 'python_version == "3.6"' don't match your environment
Ignoring dataclasses: markers 'python_version == "3.6"' don't match your environment
Ignoring importlib-resources: markers 'python_version == "3.6"' don't match your environment
Collecting oslo.concurrency===4.0.2 (from -c https://releases.openstack.org/constraints/upper/master (line 24))
  Could not find a version that satisfies the requirement oslo.concurrency===4.0.2 (from -c https://releases.openstack.org/constraints/upper/master (line 24)) (from versions: 0.1.0, 0.2.0, 0.3.0, 0.4.0, 1.4.1, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.8.1, 1.8.2, 1.9.0, 1.10.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.6.1, 2.7.0, 2.8.0, 3.0.0, 3.1.0, 3.2.0, 3.3.0, 3.4.0, 3.5.0, 3.6.0, 3.7.0, 3.7.1, 3.8.0, 3.9.0, 3.10.0, 3.11.0, 3.12.0, 3.13.0, 3.14.0, 3.14.1, 3.15.0, 3.16.0, 3.17.0, 3.18.0, 3.18.1, 3.19.0, 3.20.0, 3.21.0, 3.21.1, 3.21.2, 3.22.0, 3.23.0, 3.24.0, 3.25.0, 3.25.1, 3.26.0, 3.27.0, 3.28.0, 3.28.1, 3.29.0, 3.29.1, 3.30.0, 3.31.0)
No matching distribution found for oslo.concurrency===4.0.2 (from -c https://releases.openstack.org/constraints/upper/master (line 24))
```
