### PR TITLE
Fix CI

### DIFF
--- a/networking_calico/plugins/ml2/drivers/calico/test/test_compaction.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_compaction.py
@@ -19,7 +19,7 @@ Test compaction code.
 import logging
 import mock
 import os
-import sys
+import unittest
 
 from etcd3gw.exceptions import Etcd3Exception
 
@@ -28,10 +28,6 @@ import networking_calico.plugins.ml2.drivers.calico.test.lib as lib
 from networking_calico import etcdv3
 from networking_calico.plugins.ml2.drivers.calico import mech_calico
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
@@ -21,17 +21,12 @@ from etcd3gw import exceptions as e3e
 import eventlet
 import logging
 import mock
-import sys
+import unittest
 
 from networking_calico.compat import log
 from networking_calico import etcdv3
 from networking_calico.plugins.ml2.drivers.calico import election
 from networking_calico.plugins.ml2.drivers.calico.test import stub_etcd
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 LOG = logging.getLogger(__name__)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,3 +18,4 @@ testtools>=2.2.0 # MIT
 
 neutron>=16,<17
 neutron-lib==2.3.0
+mock>=3.0.0 # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py37,pep8
+envlist = py38,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
CI started failing, sometime since 12th June, with
```
  File "/home/semaphore/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py", line 29, in <module>
    import mock
ModuleNotFoundError: No module named 'mock'	
```
I don't know exactly what changed upstream, and when, but it appears we now need to add `mock` as a test requirement.