### PR TITLE
Make DHCP agent restart more reliable

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,6 +11,7 @@ blocks:
         - name: 'Unit and FV tests (tox)'
           commands:
             - checkout
+            - sudo apt-get update
             - sudo apt-get install -y tox
             - tox
         - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
@@ -19,6 +20,7 @@ blocks:
             - git checkout -b devstack-test
             - mkdir -p ~/calico
             - ln -s `pwd` ~/calico/networking-calico
+            - sudo apt-get update
             - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
             - sudo pip install tox
             - export LIBVIRT_TYPE=qemu

--- a/debian/calico-dhcp-agent.service
+++ b/debian/calico-dhcp-agent.service
@@ -5,8 +5,8 @@ After=syslog.target network.target
 [Service]
 User=root
 ExecStart=/usr/bin/calico-dhcp-agent --config-file /etc/neutron/neutron.conf
-KillMode=process
-Restart=on-failure
+Restart=always
+RestartSec=3
 LimitNOFILE=32000
 
 [Install]


### PR DESCRIPTION
It has been reported to us that in some circumstances (crashes caused
by other bugs) the Calico DHCP agent does not always restart
automatically, and has to be restarted manually with `systemctl
restart calico-dhcp-agent`.  We think this is because systemd does not
interpret some crash circumstances as matching `Restart=on-failure`;
changing that setting to `Restart=always` should be more reliable.  In
practice the Calico DHCP agent should always be running, unless it has
been explicitly stopped with `systemctl stop`, and `Restart=always` is
the correct setting for that desired behaviour.

We also set `RestartSec=3s` to slow down a bit if the DHCP agent is
restarting repeatedly.  Compared to the default of 100ms, this allow a
little time for contributing conditions to clear (possibly), but is
still plenty fast enough for practical DHCP service, given that DHCP
clients will retry.

Finally, remove `KillMode=process`, as this setting is now not
recommended (see [1] and [2]) - and I'm not aware that we ever had a
specific reason for choosing the `process` setting.  Removing the
setting means that `KillMode` will default to `control-group`.

[1] Current systemd.kill manpage:
https://www.freedesktop.org/software/systemd/man/systemd.kill.html

[2] Commit that added the non-recommendation:
https://github.com/systemd/systemd/commit/9b52e0d81af9c0fbdfc8686eecacc334f8d60aa8#diff-d050734015b4e77c2348f3ac3799a12e