### PR TITLE
Prevent port updates from accidentally creating etcdv3 resource

### DIFF
--- a/networking_calico/compat.py
+++ b/networking_calico/compat.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
 try:
     from neutron_lib import constants
     from neutron_lib import exceptions as n_exc

--- a/networking_calico/datamodel_v3.py
+++ b/networking_calico/datamodel_v3.py
@@ -64,8 +64,12 @@ def put(resource_kind, namespace, name, spec, annotations={}, labels=None,
       unchanged, and existing annotations with the same keys are overwritten by
       these new values.
 
-    - mod_revision (string): If specified, indicates that the write should only
-      proceed if replacing an existing value with that mod_revision.
+    - mod_revision: If 0 (a number), indicates that the write should only
+      proceed if it _creates_ the resource.  Else, if etcdv3.MUST_UPDATE,
+      indicates that the write should only proceed if it _does not create_ the
+      resource.  Else, if not None, must be a number encoded as a string,
+      e.g. "12345", and indicates that the write should only proceed if
+      replacing an existing value with that mod_revision.
 
     Returns True if the write happened successfully; False if not.
     """

--- a/networking_calico/etcdv3.py
+++ b/networking_calico/etcdv3.py
@@ -35,6 +35,10 @@ LOG = log.getLogger(__name__)
 # we leave plenty of headroom.
 CHUNK_SIZE_LIMIT = 200
 
+# Indicates that a put operation must update an existing resource and not create
+# a new resource.
+MUST_UPDATE = "MUST_UPDATE"
+
 
 class ForceClosingWatcher(watch.Watcher):
     def stop(self):
@@ -124,6 +128,7 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
               key, value, mod_revision)
     txn = {}
     if mod_revision == 0:
+        # Write operation must _create_ the KV entry.
         base64_key = _encode(key)
         txn['compare'] = [{
             'key': base64_key,
@@ -131,7 +136,17 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
             'target': 'VERSION',
             'version': 0,
         }]
+    elif mod_revision == MUST_UPDATE:
+        # Write operation must update and _not_ create the KV entry.
+        base64_key = _encode(key)
+        txn['compare'] = [{
+            'key': base64_key,
+            'result': 'NOT_EQUAL',
+            'target': 'VERSION',
+            'version': 0,
+        }]
     elif mod_revision is not None:
+        # Write operation must _replace_ an KV entry with the specified revision.
         base64_key = _encode(key)
         txn['compare'] = [{
             'key': base64_key,
@@ -140,6 +155,7 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
             'mod_revision': mod_revision,
         }]
     elif existing_value is not None:
+        # Write operation must _replace_ an KV entry with the specified value.
         base64_key = _encode(key)
         base64_existing = _encode(existing_value)
         txn['compare'] = [{

--- a/networking_calico/etcdv3.py
+++ b/networking_calico/etcdv3.py
@@ -146,7 +146,7 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
             'version': 0,
         }]
     elif mod_revision is not None:
-        # Write operation must _replace_ an KV entry with the specified revision.
+        # Write operation must _replace_ a KV entry with the specified revision.
         base64_key = _encode(key)
         txn['compare'] = [{
             'key': base64_key,
@@ -155,7 +155,7 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
             'mod_revision': mod_revision,
         }]
     elif existing_value is not None:
-        # Write operation must _replace_ an KV entry with the specified value.
+        # Write operation must _replace_ a KV entry with the specified value.
         base64_key = _encode(key)
         base64_existing = _encode(existing_value)
         txn['compare'] = [{

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -54,12 +54,12 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
 
         # Insinuate a mock etcd3gw client.
         etcdv3._client = self.clientv3 = mock.Mock()
-        self.clientv3.put.side_effect = self.check_etcd_write
-        self.clientv3.transaction.side_effect = self.etcd3_transaction
-        self.clientv3.delete.side_effect = self.etcd3_delete
-        self.clientv3.get.side_effect = self.etcd3_get
-        self.clientv3.get_prefix.side_effect = self.etcd3_get_prefix
-        self.clientv3.delete_prefix.side_effect = self.etcd3_delete_prefix
+        self.clientv3.put.side_effect = self.etcd3gw_client_put
+        self.clientv3.transaction.side_effect = self.etcd3gw_client_transaction
+        self.clientv3.delete.side_effect = self.etcd3gw_client_delete
+        self.clientv3.get.side_effect = self.etcd3gw_client_get
+        self.clientv3.get_prefix.side_effect = self.etcd3gw_client_get_prefix
+        self.clientv3.delete_prefix.side_effect = self.etcd3gw_client_delete_prefix
         self.clientv3.status.return_value = {
             'header': {'revision': '10', 'cluster_id': '1234abcd'},
         }
@@ -85,8 +85,8 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
                 _log.info("etcd reset")
                 self.assert_etcd_writes_deletes = False
 
-    def check_etcd_write(self, key, value, **kwargs):
-        """check_etcd_write
+    def etcd3gw_client_put(self, key, value, **kwargs):
+        """etcd3gw_client_put
 
         Print each etcd write as it occurs, and save into the accumulated etcd
         database.
@@ -159,7 +159,7 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
             self.assertEqual(expected, self.recent_deletes)
         self.recent_deletes = set()
 
-    def etcd3_get(
+    def etcd3gw_client_get(
         self,
         key,
         metadata=False,
@@ -202,7 +202,7 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
         else:
             return []
 
-    def etcd3_get_prefix(self, prefix):
+    def etcd3gw_client_get_prefix(self, prefix):
         self.maybe_reset_etcd()
         results = []
         for key, value in self.etcd_data.items():
@@ -215,14 +215,14 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
         _log.info("etcd3 get_prefix: %s; results: %s", prefix, results)
         return results
 
-    def etcd3_delete(self, key, **kwargs):
+    def etcd3gw_client_delete(self, key, **kwargs):
         try:
             self.check_etcd_delete(key, **kwargs)
             return True
         except lib.EtcdKeyNotFound:
             return False
 
-    def etcd3_delete_prefix(self, prefix):
+    def etcd3gw_client_delete_prefix(self, prefix):
         _log.info("etcd3 delete prefix: %s", prefix)
         for key, value in list(self.etcd_data.items()):
             if key.startswith(prefix):
@@ -230,15 +230,15 @@ class _TestEtcdBase(lib.Lib, unittest.TestCase):
                 _log.info("etcd3 deleted %s", key)
                 self.recent_deletes.add(key)
 
-    def etcd3_transaction(self, txn):
+    def etcd3gw_client_transaction(self, txn):
         if 'request_put' in txn['success'][0]:
             put_request = txn['success'][0]['request_put']
-            succeeded = self.check_etcd_write(
+            succeeded = self.etcd3gw_client_put(
                 _decode(put_request['key']).decode(),
                 _decode(put_request['value']).decode())
         elif 'request_delete_range' in txn['success'][0]:
             del_request = txn['success'][0]['request_delete_range']
-            succeeded = self.etcd3_delete(_decode(del_request['key']).decode())
+            succeeded = self.etcd3gw_client_delete(_decode(del_request['key']).decode())
         return {'succeeded': succeeded}
 
     def etcd_read(self, key, wait=False, waitIndex=None, recursive=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py38,pep8
+envlist = py38
 skipsdist = True
 
 [testenv]
@@ -15,9 +15,6 @@ commands =
     python setup.py testr --slowest --testr-args='{posargs}'
     coverage report -m
 
-[testenv:pep8]
-commands = flake8
-
 [testenv:venv]
 commands = {posargs}
 
@@ -27,11 +24,3 @@ commands = python setup.py test --coverage --coverage-package-name=networking_ca
 
 [testenv:debug]
 commands = oslo_debug_helper {posargs}
-
-[flake8]
-
-
-show-source = True
-ignore =
-builtins = _
-exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
We think this will fix a scenario where dnsmasq reports "duplicate IP" errors - i.e. that the same IP is in use by multiple VMs on the same host - and hence a newly booting VM fails to get its IP over DHCP.

Such errors reportedly follow soon after the problematic IP has been briefly used for a shortlived test VM, where:
- the test VM is booted
- connectivity is checked to and from the test VM
- the test VM is deleted again.

Especially, when the boot takes a bit longer and the connectivity checking may fail because the boot is still in progress.

Diags analysis shows that the DHCP agent sees the WorkloadEndpoint etcd resource being deleted and very quickly recreated, and then never deleted again - even though the test VM **has** been deleted - until 45 minutes later when the DHCP agent is restarted and loads a fresh full snapshot of etcd data.

I realize while writing this that there is another problem factor here.  The lead Neutron server should perform a resync, from the Neutron DB to etcd, about every minute.  So, following an update that incorrectly recreated a WorkloadEndpoint, there should be a resync within a few minutes that deletes that WorkloadEndpoint again, and the DHCP agent should see that as a deletion event.  Hence it must also be the case that the Neutron server was stuck, or not resyncing as designed, for some reason.  I will investigate that further, but think it still makes sense to fix the dynamic update per this PR.