### PR TITLE
mech_calico: Ignore pre-live-migration messages

### DIFF
--- a/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -773,6 +773,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
             # Now, fork execution based on the type of update we're performing.
             # There are a few:
+            # - a pre live-migration notice (binding profile has a migrating_to
+            #   key with the future nova-compute host as the value), which we
+            #   do nothing with right now.
             # - a port becoming bound (binding vif_type from unbound to bound);
             # - a port becoming unbound (binding vif_type from bound to
             #   unbound);
@@ -780,7 +783,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             # - an update (port bound at all times);
             # - a change to an unbound port (which we don't care about, because
             #   we do nothing with unbound ports).
-            if port_bound(port) and not port_bound(original):
+            if port['binding:profile'].get('migrating_to') is not None:
+                LOG.debug("Pre-live-migration notification message: no action")
+            elif port_bound(port) and not port_bound(original):
                 self._port_bound_update(context, port)
             elif port_bound(original) and not port_bound(port):
                 self._port_unbound_update(context, original)


### PR DESCRIPTION
As of OpenStack Newton, an RPC call push was added to pre-
live-migration steps. Reference PRs:
https://review.opendev.org/c/openstack/nova/+/275073
https://review.openstack.org/#/c/260738/

This PR adds a guard to `mech_calico`'s port updating
logic so that it effectively ignores the pre-live-migration
notification referenced above.  Without this guard,
`mech_calico` mistakeningly thinks the port is becoming
unbound/disabled (and later enabled again) as part of the
pre-live-migration notifications and flaps the VM's port
accordingly.

In short, the addition of the guard is required to avoid
an unconditional, intermittent loss of connectivity for VMs
during the live-migration process.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>