### PR TITLE
Remove PEP8 test as it's broken and we have no requirement for it now

### DIFF
--- a/networking_calico/compat.py
+++ b/networking_calico/compat.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
 try:
     from neutron_lib import constants
     from neutron_lib import exceptions as n_exc

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py38,pep8
+envlist = py38
 skipsdist = True
 
 [testenv]
@@ -15,9 +15,6 @@ commands =
     python setup.py testr --slowest --testr-args='{posargs}'
     coverage report -m
 
-[testenv:pep8]
-commands = flake8
-
 [testenv:venv]
 commands = {posargs}
 
@@ -27,11 +24,3 @@ commands = python setup.py test --coverage --coverage-package-name=networking_ca
 
 [testenv:debug]
 commands = oslo_debug_helper {posargs}
-
-[flake8]
-
-
-show-source = True
-ignore =
-builtins = _
-exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
I was seeing the error described here -
https://github.com/PyCQA/pyflakes/issues/367 - when running 'tox'
locally on my own laptop.

That issue indicates that the issue has been fixed upstream, but my
tox environment for some reason has these pins:

    flake8==2.2.4
    pyflakes==0.8.1

I guess hardcoded from within 'tox'?

Anyway, we actually have no requirement to conform to PEP8, so the
simplest thing is just to remove PEP8 testing.