### PR TITLE
Suggest installation with bird, instead of depending on it

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,13 +8,13 @@ Standards-Version: 3.9.4
 Package: calico-compute
 Architecture: all
 Depends:
- bird,
  calico-felix (>= 1.4),
  networking-calico (= ${binary:Version}),
  neutron-dhcp-agent,
  ${misc:Depends},
  ${python3:Depends},
  ${shlibs:Depends}
+Suggests: bird
 Description: Project Calico networking for OpenStack/Neutron.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. It uses IP routing to provide connectivity


### PR DESCRIPTION
Having the 'calico-compute' package depend on 'bird' is problematic
for deployments that want to use BIRD v2 (package name 'bird2') or a
BGP daemon other than BIRD, because the dependency will pull in BIRD
v1 when not actually wanted.  Fundamentally the currently declared
dependency is not a correct reflection of reality.

From a technical perspective Calico for OpenStack does not
specifically depend on BIRD v1, or on BIRD in general (any
version). The architecture of Calico for OpenStack is that Felix
programs the local VM routes on each hypervisor node, and then _any_
BGP daemon may be used to propagate those routes to other nodes in the
cluster; in principle that could be BIRD v2, Quagga, FRR etc., instead
of BIRD v1.

We at Tigera have always performed our own Calico for OpenStack
testing and validation using BIRD v1, and our 'calico-compute'
umbrella package has included 'Depends: bird' because we wanted that
package to ensure that _some_ complete solution is installed on each
compute node.  However, per the previous point (1), neither of these
points is actually required.

For the avoidance of doubt, please note that Calico for OpenStack has
never included detailed BIRD config (or config for any other BGP
daemon) as part of its product definition.  We have, for a long time,
provided some sample scripts and config, but only as examples.  (On
this point Calico for OpenStack differs from Calico for Kubernetes, as
the latter's calico-node image includes a lot of added function around
BIRD config generation.)