### PR TITLE
Update debian/control to install dh-python as a build-depend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: networking-calico
 Section: net
 Priority: optional
 Maintainer: Neil Jerram <neil@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd, python3-all, python3-setuptools
+Build-Depends: debhelper (>= 8.0.0), dh-systemd, dh-python, python3-all, python3-setuptools
 Standards-Version: 3.9.4
 
 Package: calico-compute


### PR DESCRIPTION
Closes #46.