### PR TITLE
Maybe fix tox failing

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,6 +10,9 @@ global_job_config:
   prologue:
     commands:
     - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+    - sudo apt-get update
+    - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
+    - sudo pip3 install tox
 
 blocks:
   - name: 'Testing'
@@ -18,8 +21,6 @@ blocks:
         - name: 'Unit and FV tests (tox)'
           commands:
             - checkout
-            - sudo apt-get update
-            - sudo apt-get install -y tox
             - tox
         - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
           commands:
@@ -27,9 +28,6 @@ blocks:
             - git checkout -b devstack-test
             - mkdir -p ~/calico
             - ln -s `pwd` ~/calico/networking-calico
-            - sudo apt-get update
-            - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-            - sudo pip install tox
             - export LIBVIRT_TYPE=qemu
             - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
             - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh


### PR DESCRIPTION
`tox` has been failing on master recently, see: https://tigera.semaphoreci.com/jobs/1cd2d42d-a735-41f0-893c-e7318950495e

Lots of errors like:
```Traceback (most recent call last):02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/site-packages/neutron/tests/base.py", line 398, in setUp02:05
    policy.init()02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/site-packages/neutron/policy.py", line 78, in init02:05
    register_rules(_ENFORCER)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/site-packages/neutron/policy.py", line 69, in register_rules02:05
    enforcer.register_defaults(itertools.chain(*policies))02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/site-packages/oslo_policy/policy.py", line 1119, in register_defaults02:05
    self.register_default(default)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/site-packages/oslo_policy/policy.py", line 1108, in register_default02:05
    self.registered_rules[default.name] = copy.deepcopy(default)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 180, in deepcopy02:05
    y = _reconstruct(x, memo, *rv)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 280, in _reconstruct02:05
    state = deepcopy(state, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 150, in deepcopy02:05
    y = copier(x, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 240, in _deepcopy_dict02:05
    y[deepcopy(key, memo)] = deepcopy(value, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 180, in deepcopy02:05
    y = _reconstruct(x, memo, *rv)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 280, in _reconstruct02:05
    state = deepcopy(state, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 150, in deepcopy02:05
    y = copier(x, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 240, in _deepcopy_dict02:05
    y[deepcopy(key, memo)] = deepcopy(value, memo)02:05
  File "/home/semaphore/networking-calico/.tox/py38/lib/python3.6/copy.py", line 161, in deepcopy02:05
    y = copier(memo)02:05
TypeError: cannot deepcopy this pattern object
```

This PR updates python3 packages for the tox job and updates tox itself. This seems to fix the tests.