### PR TITLE
Remove python2-etcd3gw requirement

### DIFF
--- a/rpm/networking-calico.spec.in
+++ b/rpm/networking-calico.spec.in
@@ -11,7 +11,6 @@ Source0:        networking-calico-%{version}.tar.gz
 Source45:	calico-dhcp-agent.service
 BuildArch:	noarch
 Group:          Applications/Engineering
-Requires:       python2-etcd3gw
 
 
 %description


### PR DESCRIPTION
Removing they python2-etcd3gw requirement in the rpm spec. The documentation specifies pip3 installing a specific version, so it is not needed. Closes #53 