### PR TITLE
Update to eventlet>=0.31.0 in response to dependabot security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 Babel!=2.4.0,>=2.3.4 # BSD
-eventlet!=0.18.3,!=0.20.1,!=0.21.0,!=0.23.0,>=0.18.2  # MIT
+eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
 etcd3gw>=0.2.0 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,3 +19,4 @@ testtools>=2.2.0 # MIT
 neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD
+pyroute2<0.6.0 # Apache v2


### PR DESCRIPTION
Per https://github.com/advisories/GHSA-9p9m-jm8w-94p2:

    Impact
    A websocket peer may exhaust memory on Eventlet side by sending very large websocket frames. Malicious peer may exhaust memory on Eventlet side by sending highly compressed data frame.

    Patches
    Version 0.31.0 restricts websocket frame to reasonable limits.

    Workarounds
    Restricting memory usage via OS limits would help against overall machine exhaustion. No workaround to protect Eventlet process.

    For more information
    If you have any questions or comments about this advisory:

    Open an issue in eventlet
    Contact current maintainers. At 2021-03: temotor@gmail.com or https://t.me/temotor
    References
    GHSA-9p9m-jm8w-94p2
    https://nvd.nist.gov/vuln/detail/CVE-2021-21419