### PR TITLE
etcdv3.py: Do not subclass etcd3gw.watch.Watcher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 Babel!=2.4.0,>=2.3.4 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw>=0.2.0 # Apache-2.0
+etcd3gw>=0.2.2 # Apache-2.0


### PR DESCRIPTION
`etcd3gw>=0.2.2` incorporates the fix that the subclassing
in this module itself was doing.  However, as of new
`etcd3gw`, this now results in an attempt to close the same
file descriptor twice when `stop()` is invoked, which
itself results in an exception that can result in log
spew, as seen below:

```
(WARNING) etcdv3: Failed to force-close etcd3gw's watch socket: AttributeError("'HTTPResponse' object has no attribute '_fileno'",)
```

Pin `etcd3gw` in the requirements so that the version with
the fix is used, and remove the fix incorporated in this
module.