### PR TITLE
Migration: Make sure to delete WorkloadEndpoint on old host

### DIFF
--- a/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -825,7 +825,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 else:
                     LOG.info("Port becoming bound: create.")
                     self.endpoint_syncer.write_endpoint(port,
-                                                        context._plugin_context)
+                                                        plugin_context)
             elif endpoint_should_already_exist:
                 LOG.info("Port becoming unbound: destroy.")
                 self.endpoint_syncer.delete_endpoint(original)

--- a/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -131,6 +131,16 @@ class NoResultFound(Exception):
 m_sqlalchemy.orm.exc.NoResultFound = NoResultFound
 
 
+class PortNotFound(Exception):
+
+    def __init__(self, port_id=None):
+        super(PortNotFound, self).__init__()
+        self.port_id = port_id
+
+
+m_compat.n_exc.PortNotFound = PortNotFound
+
+
 # Define a stub class, that we will use as the base class for
 # CalicoMechanismDriver.
 class DriverBase(object):
@@ -499,7 +509,10 @@ class Lib(object):
         self.db.update_port_status.reset_mock()
 
     def get_port(self, context, port_id):
-        return self.get_ports(context, filters={'id': [port_id]})[0]
+        try:
+            return self.get_ports(context, filters={'id': [port_id]})[0]
+        except IndexError:
+            raise mech_calico.n_exc.PortNotFound(port_id=port_id)
 
     def get_ports(self, context, filters=None):
         if filters is None:

--- a/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -528,13 +528,10 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # other and being handled on different Neutron servers or on different threads of
         # the same server.  The key point is that the update shouldn't accidentally
         # recreate an etcd resource that has just been deleted.
+        self.osdb_ports = [lib.port2]
         self.driver.update_port_postcommit(context)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
-
-        # Race over, and port1 gone.  Update our representation of the Neutron DB so that
-        # future queries will only get back the other port.
-        self.osdb_ports = [lib.port2]
 
         # Do another resync - expect no changes to the etcd data.
         _log.info("Resync with existing etcd data")


### PR DESCRIPTION
update_port_postcommit processing could skip calling _migration_step,
even when an actual migration was occurring, because of preceding
checks for whether the port was bound before and after the update.
Skipping _migration_step means that the WorkloadEndpoint on the old
host doesn't get deleted - at least until the next resync - and that
leaves a problem if there is a second migration of the same port back
to the old host...

In the event of a second migration of the same port back to the old
host, the problem is as follows.

- The WorkloadEndpoint still exists on the old host.  (As well as on
  the new host; these are distinct WorkloadEndpoints, even though they
  correspond to the same Neutron port at different times of its life.)

- Nova recreates the tap interface, on the old host, very early on
  during the second migration process.  (So that it is possible to
  create a new VM there and start migrating to it.)

- As soon as the interface exists, as well as the WorkloadEndpoint,
  Felix (+ BIRD) starts advertising out that the WorkloadEndpoint's IP
  exists on that host.

- But in fact this is way too early, because the new VM isn't yet
  ready, and it causes problems that the same IP is being advertised out
  from both the old and the new host.

To eliminate that problem, it is important to delete the
WorkloadEndpoint on the old host when the process of migration to a
new host completes.  `_migration_step` was designed to do this, but it
wasn't being hit (at least in Rocky and Ussuri) because we were
instead hitting this prior if condition:

     elif port_bound(port) and not port_bound(original):
         LOG.info("Port becoming bound: create.")
         self.endpoint_syncer.write_endpoint(port,
                                             context._plugin_context)

In other words, in recent OpenStack releases, it appears that the
`original` port is marked as being unbound, in the
update_port_postcommit callback that also updates `binding:host_id`.

To fix that, and generally try to make the update logic more robust:

- Check upfront for a `binding:host_id` change, independent of port
  bound state, and delete the old WorkloadEndpoint in that case.

- Eliminate the `_migration_step` code and case, as it now reduces to
  just creating or updating the new WorkloadEndpoint, and that is
  already handled by other cases.

- Comment in detail about why we re-read the port data.

- Use `port_unbound` utility function in `_update_port`, instead of
  its own equivalent.

- Remove unnecessary commenting in `_update_port`.