### PR TITLE
Merge pull request #58 from bloomberg/fix-etcd3gw-watcher-close

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 Babel!=2.4.0,>=2.3.4 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw>=0.2.0 # Apache-2.0
+etcd3gw>=0.2.2 # Apache-2.0


### PR DESCRIPTION
etcdv3.py: Do not subclass etcd3gw.watch.Watcher