### PR TITLE
Fix networking-calico CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,6 +34,11 @@ blocks:
             - ln -s `pwd` ~/calico/networking-calico
             - export LIBVIRT_TYPE=qemu
             - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+            # Use fork of the OpenStack requirements repo, while waiting for
+            # https://review.opendev.org/c/openstack/requirements/+/810859 to be merged or
+            # for an equivalent upstream fix.  See commit message for more context.
+            - export REQUIREMENTS_REPO=https://github.com/neiljerram/requirements.git
+            - export REQUIREMENTS_BRANCH=pin-setuptools
             - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
       epilogue:
         on_fail:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,8 +11,12 @@ global_job_config:
     commands:
     - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
     - sudo apt-get update
-    - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
+    - sudo apt-get install -y python-all-dev python3-all-dev python3-pip crudini
     - sudo pip3 install tox
+    # Disable initramfs update, as it means we run out of space on the Semaphore
+    # VM (and we don't need it because we're not going to reboot).
+    - sudo crudini --set /etc/initramfs-tools/update-initramfs.conf '' update_initramfs no
+    - cat /etc/initramfs-tools/update-initramfs.conf
 
 blocks:
   - name: 'Testing'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,11 +34,11 @@ blocks:
             - ln -s `pwd` ~/calico/networking-calico
             - export LIBVIRT_TYPE=qemu
             - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-            # Use fork of the OpenStack requirements repo, while waiting for
-            # https://review.opendev.org/c/openstack/requirements/+/810859 to be merged or
-            # for an equivalent upstream fix.  See commit message for more context.
-            - export REQUIREMENTS_REPO=https://github.com/neiljerram/requirements.git
-            - export REQUIREMENTS_BRANCH=pin-setuptools
+            # Use proposed fix at
+            # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+            # message for more context.
+            - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+            - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
             - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
       epilogue:
         on_fail:


### PR DESCRIPTION
Problem #1:
```
Setting up apache2-dev (2.4.29-1ubuntu4.18) ...
Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
Processing triggers for mime-support (3.60ubuntu1) ...
Processing triggers for ureadahead (0.100.0-21) ...
Processing triggers for install-info (6.5.0.dfsg.1-2) ...
Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
update-initramfs: Generating /boot/initrd.img-5.4.0-84-generic

gzip: stdout: No space left on device
E: mkinitramfs failure cpio 141 gzip 1
update-initramfs: failed for /boot/initrd.img-5.4.0-84-generic with 1.
```

After fixing that, problem #2:
```
Requirement already satisfied: sqlparse===0.3.1 in /usr/local/lib/python3.6/dist-packages (from -c /opt/stack/requirements/upper-constraints.txt (line 895)) (0.3.1)
Requirement already satisfied: statsd===3.3.0 in /usr/local/lib/python3.6/dist-packages (from -c /opt/stack/requirements/upper-constraints.txt (line 896)) (3.3.0)
Requirement already satisfied: stevedore===1.32.0 in /usr/local/lib/python3.6/dist-packages (from -c /opt/stack/requirements/upper-constraints.txt (line 901)) (1.32.0)
Collecting suds-jurko===0.6
  Downloading suds-jurko-0.6.tar.bz2 (143 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3.6 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-p0znzn4l/suds-jurko/setup.py'"'"'; __file__='"'"'/tmp/pip-install-p0znzn4l/suds-jurko/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-yhj26ocs
         cwd: /tmp/pip-install-p0znzn4l/suds-jurko/
    Complete output (1 lines):
    error in suds-jurko setup command: use_2to3 is invalid.
```